### PR TITLE
Add a close method to Socket

### DIFF
--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1493,7 +1493,7 @@ class Socket:
                                 continue
                             subscription.handle_event(event, data)
                     except errors.NoReconnect as e:
-                        raise e # propegate the error to be handled later.
+                        raise e
                     except Exception as e:
                         utils.print_exception_with_header(
                             "Ignoring exception when parsing WebSocket message", e

--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1438,8 +1438,8 @@ class Socket:
     async def close(self) -> None:
         if self.kit.aiohttp_session is None or self.ws.closed == True):
             return
-        self.ws.close()
-        self.task.cancel() # might need a try except on this to handle task exception.
+        await self.ws.close()
+        await self.task.cancel() # might need a try except on this to handle task exception.
 
     async def actual_run(self) -> None:
         while True:

--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1439,7 +1439,7 @@ class Socket:
         if self.kit.aiohttp_session is None or self.ws.closed == True):
             return
         await self.ws.close()
-        await self.task.cancel() # might need a try except on this to handle task exception.
+        self.task.cancel() # might need a try except on this to handle task exception.
 
     async def actual_run(self) -> None:
         while True:

--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1436,10 +1436,10 @@ class Socket:
             await self.subscribe(subscription)
             
     async def close(self) -> None:
-        if self.kit.aiohttp_session is None or self.ws.closed == True):
+        if self.kit.aiohttp_session is None or self.ws.closed or self.task is None:
             return
-        await self.ws.close()
-        self.task.cancel() # might need a try except on this to handle task exception.
+        await self.ws.close(code=1002)
+        self.task.cancel()
 
     async def actual_run(self) -> None:
         while True:


### PR DESCRIPTION
Adds a method to close a socket. Adds a way to exit the while True loop if the WebSocket is closed with no error code. The close method itself first closes the socket, and then the task is canceled.

I haven't tested the code yet.