### PR TITLE
Add a try/except block to handle non-json return from server

### DIFF
--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1353,9 +1353,8 @@ class Subscription(Generic[T]):
                 if data.get("error") is not None:
                     raise errors.SubscribeError(data["error"])
                 return data["channel"]
-            except aiohttp.client_exceptions.ContentTypeError:
-                logger.exception("Failed to get json from response.")
-                raise errors.SubscribeError("Failed to get json from response.")
+            except aiohttp.client_exceptions.ContentTypeError as e:
+                raise errors.SubscribeError(e.message)
 
     async def unsubscribe(self) -> None:
         """Unsubscribe from the subscription"""

--- a/pnwkit/new.py
+++ b/pnwkit/new.py
@@ -1354,7 +1354,7 @@ class Subscription(Generic[T]):
                     raise errors.SubscribeError(data["error"])
                 return data["channel"]
             except aiohttp.client_exceptions.ContentTypeError as e:
-                raise errors.SubscribeError(e.message)
+                raise errors.SubscribeError(e.message) from e
 
     async def unsubscribe(self) -> None:
         """Unsubscribe from the subscription"""


### PR DESCRIPTION
This is an attempt to help make it easier to handle the following unhandled exception.

Traceback example:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 1663, in subscribe
    auth = await self.authorize_subscription(subscription)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 1636, in authorize_subscription
    raise errors.Unauthorized()
pnwkit.errors.Unauthorized

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/bot/cogs/subscriptions.py", line 67, in add_subscription
    ] = await self.bot.pnwapi.subscribe(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 509, in subscribe
    return await Subscription[Any].subscribe(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 1325, in subscribe
    await self.kit.subscribe_internal(self)
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 550, in subscribe_internal
    await self.socket.subscribe(subscription)
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 1666, in subscribe
    subscription.channel = await subscription.request_channel()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pnwkit/new.py", line 1349, in request_channel
    data = await response.json()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 1104, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: text/html', url=URL('https://api.politicsandwar.com/subscriptions/v1/subscribe/account/update?api_key=xxxxxxxx')
```

I did not add in a way for it to retry if this happens, only raise the SubscribeError exception.