### PR TITLE
Adding recent projects not currently in data.py

### DIFF
--- a/pnwkit/data.py
+++ b/pnwkit/data.py
@@ -243,12 +243,16 @@ class Nation(Data):
     arms_stockpile: bool
     egr: bool
     emergency_gasoline_reserve: bool
+    fallout_shelter: bool
+    fallouts: bool
     massirr: bool
     mass_irrigation: bool
     itc: bool
     international_trade_center: bool
     mlp: bool
     missile_launch_pad: bool
+    military_salvage: bool
+    militarys: bool
     nrf: bool
     nuclear_research_facility: bool
     irond: bool
@@ -267,6 +271,8 @@ class Nation(Data):
     urban_planning: bool
     adv_city_planning: bool
     advanced_urban_planning: bool
+    metro_planning: bool
+    metropolitan_planning: bool
     space_program: bool
     spy_satellite: bool
     moon_landing: bool

--- a/pnwkit/data.py
+++ b/pnwkit/data.py
@@ -244,7 +244,6 @@ class Nation(Data):
     egr: bool
     emergency_gasoline_reserve: bool
     fallout_shelter: bool
-    fallouts: bool
     massirr: bool
     mass_irrigation: bool
     itc: bool
@@ -252,7 +251,6 @@ class Nation(Data):
     mlp: bool
     missile_launch_pad: bool
     military_salvage: bool
-    militarys: bool
     nrf: bool
     nuclear_research_facility: bool
     irond: bool
@@ -271,7 +269,6 @@ class Nation(Data):
     urban_planning: bool
     adv_city_planning: bool
     advanced_urban_planning: bool
-    metro_planning: bool
     metropolitan_planning: bool
     space_program: bool
     spy_satellite: bool

--- a/pnwkit/ext/dumps/data.py
+++ b/pnwkit/ext/dumps/data.py
@@ -350,8 +350,14 @@ class DumpNation(DumpData):
         Whether the nation has the Arms Stockpile project or not.
     emergency_gasoline_reserve_np: :class:`bool`
         Whether the nation has the Emergency Gasoline Reserve project or not.
+    fallout_shelter_np: :class:`bool`
+        Whether the nation has the Fallout Shelter project or not.
     mass_irrigation_np: :class:`bool`
         Whether the nation has the Mass Irrigation project or not.
+    military_salvage_np: :class:`bool`
+        Whether the nation has the Military Salvage project or not.
+    metropolitan_planning_np: :class:`bool`
+        Whether the nation has the Metropolitan Planning project or not.
     international_trade_center_np: :class:`bool`
         Whether the nation has the International Trade Center project or not.
     missile_launch_pad_np: :class:`bool`


### PR DESCRIPTION
I noticed in VSCode, metropolitan_planning was getting the proper data without error but was not highlighting and showing as a boolean. Sure enough, that and a few other projects were missing from here. So I just added them.

Closes #9 